### PR TITLE
replaced tfms with ds_tfms

### DIFF
--- a/food-detector.py
+++ b/food-detector.py
@@ -39,7 +39,7 @@ app = Starlette()
 
 path = Path("/tmp")
 classes = ['healthy', 'junk']
-data = ImageDataBunch.single_from_classes(path, classes, tfms=get_transforms(), size=224).normalize(imagenet_stats)
+data = ImageDataBunch.single_from_classes(path, classes, ds_tfms=get_transforms(), size=224).normalize(imagenet_stats)
 learner = create_cnn(data, models.resnet50)
 learner.model.load_state_dict(
     torch.load("model-weights.pth", map_location="cpu")


### PR DESCRIPTION
replaced tfms with ds_tfms in food_detector.py. 
tfms no longer works on future version of FastAI. This[ forum post](https://forums.fast.ai/t/transform-got-multiple-values-for-argument-tfms-lesson-2/37975) on FastAI shows the solution.